### PR TITLE
Fixed import error I was getting when importing keras

### DIFF
--- a/notebooks/utils/preprocessing.py
+++ b/notebooks/utils/preprocessing.py
@@ -1,4 +1,4 @@
-from keras.preprocessing.image import load_img, img_to_array, array_to_img
+from keras_preprocessing.image import load_img, img_to_array, array_to_img
 import tensorflow as tf
 import os
 


### PR DESCRIPTION
I ran into an error like this stackoverflow question when running the notebook. Changing `keras.preprocessing` to `keras_preprocessing` in preprocessing.py fixed the issue.
https://stackoverflow.com/questions/72479044/cannot-import-name-load-img-from-keras-preprocessing-image

Let me know if this change causes problems on your setups.